### PR TITLE
use yarn to install dependencies in the lambda package

### DIFF
--- a/bin/lambda-prep.js
+++ b/bin/lambda-prep.js
@@ -42,7 +42,7 @@ exec(`${babel} lambda.js --out-file lambda.js`);
 
 console.log(`installing`);
 // then download the dependencies
-exec(`npm install --production`);
+exec(`yarn install --production`);
 
 // Identify dependencies that specify a 'babelify' transform in its package.json
 let babelifyPackages = fs.readdirSync(`node_modules`)


### PR DESCRIPTION
now that yarn has a --production flag  because that's how the modules expect to work.

NB, I'm still not using yarn pack because it's harder to parse its output to get the name of the .tgz file.