### PR TITLE
Include .babelrc when packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "fs-extra": "^2.0.0"
   },
   "files": [
+    ".babelrc",
     "src",
     "bin"
   ],


### PR DESCRIPTION
To keep ember-browserify/babelify happy when including in Ember projects