### PR TITLE
add Xml properties mixin to persist data in an xml properties element

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,17 +1,12 @@
 module.exports = {
   root: true,
-  parserOptions: {
-    ecmaVersion: 6,
-    sourceType: 'script'
-  },
-  extends: [
-    'eslint:recommended'
-  ],
   env: {
-    'node': true,
     'es6': true
   },
+  extends: [
+    'plugin:turbopatent/node'
+  ],
   rules: {
-    "no-unused-vars": [ "error", { vars: "all", args: "none" }]
+    'no-var': 'error'
   }
 };

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -5,8 +5,5 @@ module.exports = {
   },
   extends: [
     'plugin:turbopatent/node'
-  ],
-  rules: {
-    'no-var': 'error'
-  }
+  ]
 };

--- a/bin/lambda-prep.js
+++ b/bin/lambda-prep.js
@@ -19,7 +19,7 @@ let path = require('path');
 let { execSync } = require('child_process');
 
 function exec(command) {
-  return execSync(command, {encoding: 'utf-8'});
+  return execSync(command, { encoding: 'utf-8' });
 }
 
 console.log(`packing`);
@@ -84,10 +84,10 @@ fixBinsInPackages(`node_modules`);
 // Identify dependencies that specify a 'babelify' transform in its package.json
 let babelifyPackages = listFiles(`node_modules`)
   .filter((dir) => {
-  let { browserify = {} } = require(`${process.cwd()}/node_modules/${dir}/package`);
-  let { transform = [[]] } = browserify;
-  return transform[0][0] === 'babelify';
-});
+    let { browserify = {} } = require(`${process.cwd()}/node_modules/${dir}/package`);
+    let { transform = [ [] ] } = browserify;
+    return transform[0][0] === 'babelify';
+  });
 
 // transpile each babelify dependency in place
 console.log(

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "license": "NONE",
   "devDependencies": {
     "eslint": "^3.12.1",
-    "eslint-plugin-turbopatent": "^0.1.0",
+    "eslint-plugin-turbopatent": "^0.5.0",
     "git-release": "^0.6.0",
     "tap-diff": "^0.1.1",
     "tape": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babelify": "^7.3.0",
     "block-re": "git+https://github.com/chadkirby/block-re.git",
     "cheerio": "^0.22.0",
+    "detect-node": "^2.0.3",
     "fs-extra": "^2.0.0"
   },
   "files": [

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "license": "NONE",
   "devDependencies": {
     "eslint": "^3.12.1",
+    "eslint-plugin-turbopatent": "^0.1.0",
     "git-release": "^0.6.0",
     "tap-diff": "^0.1.1",
     "tape": "^4.6.2",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "babel-preset-es2015": "^6.18.0",
     "babelify": "^7.3.0",
     "block-re": "git+https://github.com/chadkirby/block-re.git",
+    "cheerio": "^0.22.0",
     "fs-extra": "^2.0.0"
   },
   "files": [

--- a/src/index.js
+++ b/src/index.js
@@ -11,3 +11,4 @@ exports.GetMixin = require('./get-mixin');
 exports.makeNSTagSelector = require('./make-ns-tag-selector');
 
 exports.XmlPropertiesMixin = require('./xml-properties-mixin');
+exports.XmlNamespaceMixin = require('./xml-namespace-mixin');

--- a/src/index.js
+++ b/src/index.js
@@ -9,3 +9,5 @@ exports.mix = require('./mixwith');
 exports.GetMixin = require('./get-mixin');
 
 exports.makeNSTagSelector = require('./make-ns-tag-selector');
+
+exports.XmlPropertiesMixin = require('./xml-properties-mixin');

--- a/src/make-ns-tag-selector.js
+++ b/src/make-ns-tag-selector.js
@@ -36,7 +36,7 @@ function makeNSTagSelector(namespace = '') {
   // but the thing does not need a namespace if it is the namespace (followed by a
   // colon)
   (?! \\* : )
-  `
+  `;
 
   return function(strings, ...keys) {
     let out = '';

--- a/src/make-ns-tag-selector.js
+++ b/src/make-ns-tag-selector.js
@@ -33,9 +33,6 @@ function makeNSTagSelector(namespace = '') {
 
   // capture the namespace-needing thing
   (\w+)
-  // but the thing does not need a namespace if it is the namespace (followed by a
-  // colon)
-  (?! \\* : )
   `;
 
   return function(strings, ...keys) {
@@ -55,7 +52,7 @@ function makeNSTagSelector(namespace = '') {
     // cheerio dom object into a selector. E.g., if you wanted to get the sib of
     // an element if the sib has the same tag as the element, you might do
     // something like so: ({name} = $wr[0]); $sib = $wr.next(w`${name}`)
-    return namespaced.replace(re('g')`${namespace}:`, `${namespace}\\:`);
+    return namespaced.replace(re('g')`\b${namespace}:`, `${namespace}\\:`);
   };
 }
 

--- a/src/make-ns-tag-selector.js
+++ b/src/make-ns-tag-selector.js
@@ -1,42 +1,43 @@
 let re = require('block-re');
 
-const needsNamespace = re('g')`
-(
-  // a thing that needs a namespace can begin the string; but the beginning of
-  // the string does not need a namespace if it begins with 1+ word chars
-  // followed by a colon
-  ^ (?! \w+ \\* :)
-  |
-  // or a thing that needs a namespace can be preceded by any of several chars
-
-  // a namespace-needing thing can be preceded by an open bracket e.g.,
-  // [foo="1"] => [w:foo="1"]
-
-  // a namespace-needing thing can follow an open paren, e.g.,
-  // :has(foo) => :has(w:foo)
-
-  // a namespace-needing thing can follow a comma, e.g.,
-  // foo,bar => w:foo,w:bar
-
-  // a namespace-needing thing can follow whitespace, e.g.,
-  // foo bar => w:foo w:bar
-
-  [ [ ( , \s ]
-) // close capture group of the stuff before the namespace-needing thing
-
-// capture the namespace-needing thing
-(\w+)
-// but the thing does not need a namespace if it is the namespace (followed by a
-// colon)
-(?! \\* : )
-`
-
-function makeNSTagSelector(namespace) {
+function makeNSTagSelector(namespace = '') {
   //
   // w is a template-tag function for escaping* and name-spacing ooxml selectors
   // e.g., w`p` => `w\\:p`
   // * cheerio requires that the colon following the namespace be escaped
   //
+  const needsNamespace = re('g')`
+  (
+    // a thing that needs a namespace can begin the string
+    ^
+    |
+    // or a thing that needs a namespace can be preceded by any of several chars
+
+    // a namespace-needing thing can be preceded by an open bracket e.g.,
+    // [foo="1"] => [w:foo="1"]
+
+    // a namespace-needing thing can follow an open paren, e.g.,
+    // :has(foo) => :has(w:foo)
+
+    // a namespace-needing thing can follow a comma, e.g.,
+    // foo,bar => w:foo,w:bar
+
+    // a namespace-needing thing can follow whitespace, e.g.,
+    // foo bar => w:foo w:bar
+
+    [ [ ( , \s ]
+  ) // close capture group of the stuff before the namespace-needing thing
+
+  // thing does not need a namespace if it is the namespace
+  (?! ${namespace} \\* :)
+
+  // capture the namespace-needing thing
+  (\w+)
+  // but the thing does not need a namespace if it is the namespace (followed by a
+  // colon)
+  (?! \\* : )
+  `
+
   return function(strings, ...keys) {
     let out = '';
     for (let index = 0; index < strings.length; index++) {

--- a/src/mixwith.js
+++ b/src/mixwith.js
@@ -12,6 +12,6 @@ class Mixer {
   }
 }
 
-function mix(superclass = class{}) {
+function mix(superclass = class {}) {
   return new Mixer(superclass);
 }

--- a/src/report-unless.js
+++ b/src/report-unless.js
@@ -1,8 +1,11 @@
 /* eslint-disable no-console */
 
+let isNode = require('detect-node');
+
 function reportUnless(predicate, message, options = {}) {
   let {
-    isUnitTest = global && global.TESTING,
+    // we can't be in a unit test unless we're running in node
+    isUnitTest = isNode ? global.TESTING : false,
     log = console.error
   } = options;
 

--- a/src/report-unless.js
+++ b/src/report-unless.js
@@ -1,0 +1,21 @@
+/* eslint-disable no-console */
+
+function reportUnless(predicate, message, options = {}) {
+  let {
+    isUnitTest = global && global.TESTING,
+    log = console.error
+  } = options;
+
+  if (predicate) {
+    // we did not report, so return false
+    return false;
+  }
+  if (isUnitTest) {
+    throw new Error(message);
+  }
+  log(message);
+  // we did report, so return true
+  return true;
+}
+
+module.exports = reportUnless;

--- a/src/xml-namespace-mixin.js
+++ b/src/xml-namespace-mixin.js
@@ -1,0 +1,27 @@
+const re = require('block-re');
+
+const makeNSTagSelector = require('./make-ns-tag-selector');
+
+//
+// mixin to handle a namespace property
+//
+
+let XmlNamespaceMixin = (superclass) => class extends superclass {
+  constructor(root, { namespace } = {}) {
+    super(...arguments);
+    this.namespace = namespace;
+    this.makeNSSelector = makeNSTagSelector(namespace);
+  }
+  ensureNamespace(tag) {
+    let { namespace } = this;
+    if (!namespace) {
+      return tag;
+    }
+    return tag.replace(re()`^(?!${namespace}:)`, `${namespace}:`);
+  }
+  toSelector(tag) {
+    return this.makeNSSelector`${tag}`;
+  }
+};
+
+module.exports = XmlNamespaceMixin;

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -15,8 +15,8 @@ const $ = cheerio.load(`<?xml version="1.0" ?>`, { xmlMode: true });
 // properties.foo = { bar: 5, baz: 'bat' } ==> <foo bar="5", baz="bat"/>
 //
 // array elements
-// properties.push('foo', {bar: 5})
-// properties.push('foo', {bar: 6})
+// properties.pushToArray('foo', {bar: 5})
+// properties.pushToArray('foo', {bar: 6})
 // ==> <foo bar="5"/><foo bar="6"/>
 //
 
@@ -114,12 +114,12 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     // remove existing elements
     this.removeProperty(tag);
     // set the new elements
-    attrList.forEach((attrs) => this.push(tag, attrs, $Pr));
+    attrList.forEach((attrs) => this.pushToArray(tag, attrs, $Pr));
   }
   //
   // add one array-item having the given attributes for the given tag
   //
-  push(tag, attrs = {}, $Pr = this.ensurePr()) {
+  pushToArray(tag, attrs = {}, $Pr = this.ensurePr()) {
     let $tag = $(`<${this.ensureNamespace(tag)}/>`);
     $Pr.append($tag);
     this.setAttrs($tag, attrs);

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -1,7 +1,5 @@
 const cheerio = require('cheerio');
 
-const reportUnless = require('./report-unless');
-
 const $ = cheerio.load(`<?xml version="1.0" ?>`, { xmlMode: true });
 
 //
@@ -28,10 +26,16 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   //
   constructor(root, { propertiesTag } = {}) {
     super(...arguments);
-    reportUnless(propertiesTag, `need propertiesTag for XmlProperties`);
+    if (!propertiesTag) {
+      // a missing propertiesTag is an unrecoverable error
+      throw new Error(`need propertiesTag for XmlProperties`);
+    }
     this.propertiesTag = propertiesTag;
     this.$root = $(root);
-    reportUnless(this.$root.length, `need root for XmlProperties`);
+    if (!this.$root.length) {
+      // a missing $root is an unrecoverable error
+      throw new Error(`need root for XmlProperties`);
+    }
   }
   //
   // get the $Pr element where our properties are stored

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -60,6 +60,12 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     return $prop;
   }
   //
+  // remove our $Pr element
+  //
+  removePr() {
+    return this.$Pr.remove();
+  }
+  //
   // find the $element corresponding to a given tag in our $Pr element
   //
   findProperty(tag) {
@@ -129,8 +135,10 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   // get a scalar value for the given tag
   //
   getScalar(tag) {
-    let $el = this.ensureProperty(tag);
-    return $el.attr('val');
+    let $el = this.findProperty(tag);
+    if ($el) {
+      return $el.attr('val');
+    }
   }
   //
   // set a scalar value for the given tag as the 'val' atribute of its element
@@ -139,6 +147,20 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     let $el = this.ensureProperty(tag);
     this.setAttrs($el, { val });
     return val;
+  }
+  //
+  // set a scalar value for the given tag as the 'val' atribute of its element,
+  // or remove the element if the value is falsy
+  //
+  setOrRemoveScalar(tag, val) {
+    if (!val) {
+      let $prop = this.findProperty(tag);
+      if ($prop) {
+        $prop.remove();
+      }
+      return val;
+    }
+    return this.setScalar(tag, val);
   }
   //
   // get a boolean value indicating whether an element for the given tag eists
@@ -163,7 +185,10 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   // get a pojo corresponding to the attributes of the element corresponding to the given tag
   //
   getHash(tag) {
-    let $el = this.ensureProperty(tag);
+    let $el = this.findProperty(tag);
+    if (!$el) {
+      return {};
+    }
     return $el.attr();
   }
   //

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -1,0 +1,151 @@
+const re = require('block-re');
+const cheerio = require('cheerio');
+
+const makeNSTagSelector = require('./make-ns-tag-selector');
+
+const $ = cheerio.load(`<?xml version="1.0" ?>`, { xmlMode: true });
+
+//
+// mixin to persist data in an xml properties element, similar to how properties
+// are stored in pPr/rPr elements in ooxml.
+//
+// numbers and strings are stored as the 'val' attribute of an element, e.g.
+// properties.foo = 5 ==> <foo val="5"/>
+//
+// key: value objects
+// properties.foo = { bar: 5, baz: 'bat' } ==> <foo bar="5", baz="bat"/>
+//
+// array elements
+// properties.push('foo', {bar: 5})
+// properties.push('foo', {bar: 6})
+// ==> <foo bar="5"/><foo bar="6"/>
+//
+
+let XmlPropertiesMixin = (superclass) => class extends superclass {
+  constructor(root, propertiesTag, namespace) {
+    if (!propertiesTag) {
+      throw new Error(`need propertiesTag for XmlProperties`);
+    }
+    super();
+      // accept either an XmlProperties object (with a .$root property) or a dom element
+    this.$root = root.$root || $(root);
+    if (!this.$root.length) {
+      throw new Error(`need root for XmlProperties`);
+    }
+    this.propertiesTag = propertiesTag;
+    this.namespace = namespace;
+    this.makeNSSelector = makeNSTagSelector(namespace);
+  }
+  ensureNamespace(tag) {
+    let { namespace } = this;
+    if (!namespace) {
+      return tag;
+    }
+    return tag.replace(re()`^(?!${namespace}:)`, `${namespace}:`);
+  }
+  toSelector(tag) {
+    return this.makeNSSelector`${tag}`;
+  }
+  html() {
+    return $.html(this.$Pr);
+  }
+  get $Pr() {
+    return this.$root.find(`> ${this.toSelector(this.propertiesTag)}`);
+  }
+  ensurePr() {
+    let $prop = this.$Pr;
+    if (!$prop.length) {
+      $prop = $(`<${this.ensureNamespace(this.propertiesTag)}/>`);
+      this.$root.prepend($prop);
+    }
+    return $prop;
+  }
+  findProperty(tag) {
+    let $prop = this.$Pr.find(`> ${this.toSelector(tag)}`);
+    if ($prop.length) {
+      return $prop;
+    }
+  }
+  ensureProperty(tag) {
+    let $prop = this.findProperty(tag);
+    if (!$prop) {
+      $prop = $(`<${this.ensureNamespace(tag)}/>`);
+      this.ensurePr().append($prop);
+    }
+    return $prop;
+  }
+  removeProperty(tag) {
+    let $prop = this.findProperty(tag);
+    if ($prop) {
+      $prop.remove();
+    }
+  }
+  getPropertyValue(tag) {
+    let $prop = this.findProperty(tag);
+    if ($prop) {
+      return this.getVal($prop);
+    }
+  }
+  getArrayPropertyValue(tag) {
+    let vals = this.getPropertyValue(tag);
+      // ensure we return an array
+    if (!vals) {
+      return [];
+    }
+    if (Array.isArray(vals)) {
+      return vals;
+    }
+    return [ vals ];
+
+  }
+  setArrayProperty(tag, attrList, $Pr = this.ensurePr()) {
+      // remove existing elements
+    this.removeProperty(tag);
+    if (!(attrList && attrList.length)) {
+      return;
+    }
+    attrList.forEach((attrs) => this.push(tag, attrs, $Pr));
+
+  }
+  push(tag, attrs, $Pr = this.ensurePr()) {
+    if (!attrs) {
+      return;
+    }
+    let $tag = $(`<${this.ensureNamespace(tag)}/>`);
+    $Pr.append($tag);
+    this.setAttrs($tag, attrs);
+    return $tag;
+  }
+  setAttrs(el, attrs) {
+    Object.keys(attrs).forEach((key) => {
+      $(el).attr(key, attrs[key]);
+    });
+  }
+  getVal(el) {
+    if (!el) {
+      return;
+    }
+    let $el = el.cheerio ? el : $(el);
+    if ($el.length > 1) {
+      return $el.toArray().map((item) => this.getVal(item));
+    }
+    let attrs = $el.attr();
+    let keys = Object.keys(attrs);
+    let attrCount = keys.length;
+    if (attrCount === 0) {
+      // if no attrs, the property is a boolean. as the element exists, return true
+      return true;
+    }
+    let [ key ] = keys;
+    // if the element has only one attribute, named 'val', then return the value
+    // of that attribute
+    if (attrCount === 1 && key === 'val') {
+      return attrs[key];
+    }
+    // otherwise, return a POJO with all of the attribute key: value pairs
+    return attrs;
+  }
+
+};
+
+module.exports = XmlPropertiesMixin;

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -200,6 +200,10 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     this.setAttrs($el, pojo);
     return pojo;
   }
+
+  copyAs(NewPropsClass) {
+    return new NewPropsClass(this.$root);
+  }
 };
 
 module.exports = XmlPropertiesMixin;

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -130,7 +130,7 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   //
   getScalar(tag) {
     let $el = this.ensureProperty(tag);
-    return $el.attr('val')
+    return $el.attr('val');
   }
   //
   // set a scalar value for the given tag as the 'val' atribute of its element
@@ -153,7 +153,7 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   setBool(tag, yesNo) {
     let $el = this.ensureProperty(tag);
     if (yesNo) {
-      this.setAttrs($el, true)
+      this.setAttrs($el, true);
     } else {
       $el.remove();
     }

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -1,5 +1,7 @@
 const cheerio = require('cheerio');
 
+const reportUnless = require('./report-unless');
+
 const $ = cheerio.load(`<?xml version="1.0" ?>`, { xmlMode: true });
 
 //
@@ -25,16 +27,11 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   // make a new instance, given a root element and a propertiesTag
   //
   constructor(root, { propertiesTag } = {}) {
-    if (!propertiesTag) {
-      throw new Error(`need propertiesTag for XmlProperties`);
-    }
     super(...arguments);
-    // accept either an XmlProperties object (with a .$root property) or a dom element
-    this.$root = root.$root || $(root);
-    if (!this.$root.length) {
-      throw new Error(`need root for XmlProperties`);
-    }
+    reportUnless(propertiesTag, `need propertiesTag for XmlProperties`);
     this.propertiesTag = propertiesTag;
+    this.$root = $(root);
+    reportUnless(this.$root.length, `need root for XmlProperties`);
   }
   //
   // get the $Pr element where our properties are stored
@@ -199,7 +196,6 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     this.setAttrs($el, pojo);
     return pojo;
   }
-
 };
 
 module.exports = XmlPropertiesMixin;

--- a/tests/cacher8r-mixin-test.js
+++ b/tests/cacher8r-mixin-test.js
@@ -15,19 +15,19 @@ test('CacheR8R caches properties', function(assert) {
       this.html = 'hi there';
     }
     get aa() {
-      return this.cacheOrCompute(['aa'], () => {
+      return this.cacheOrCompute([ 'aa' ], () => {
         aaComputed += 1;
         return 'aa';
       });
     }
     get bb() {
-      return this.cacheOrCompute(['bb', this.xx], () => {
+      return this.cacheOrCompute([ 'bb', this.xx ], () => {
         bbComputed += 1;
         return this.xx;
       });
     }
     get cc() {
-      return this.cacheOrCompute([this.strHash(this.html)], () => {
+      return this.cacheOrCompute([ this.strHash(this.html) ], () => {
         ccComputed += 1;
         return this.html;
       });

--- a/tests/get-test.js
+++ b/tests/get-test.js
@@ -5,6 +5,9 @@ let realTest = require('tape-catch');
 module.exports = getTest;
 
 function getTest() {
+  if (global) {
+    global.TESTING = true;
+  }
   let testFile = path.basename(module.parent.filename, '.js');
   function test(description, ...args) {
     // add the name of the test-file to the description

--- a/tests/make-ns-tag-selector-test.js
+++ b/tests/make-ns-tag-selector-test.js
@@ -2,7 +2,7 @@ let test = require('./get-test')();
 let makeNSTagSelector = require('../src/make-ns-tag-selector');
 
 test('makeNSTagSelector escapes and name-spaces a selector', function(assert) {
-  let w = makeNSTagSelector(`w`)
+  let w = makeNSTagSelector(`w`);
   assert.equal(
     w`p`,
     `w\\:p`

--- a/tests/make-ns-tag-selector-test.js
+++ b/tests/make-ns-tag-selector-test.js
@@ -14,6 +14,11 @@ test('makeNSTagSelector escapes and name-spaces a selector', function(assert) {
   );
 
   assert.equal(
+    w`w\\:p`,
+    `w\\:p`
+  );
+
+  assert.equal(
     w`${w`w:p`}`,
     `w\\:p`
   );

--- a/tests/make-ns-tag-selector-test.js
+++ b/tests/make-ns-tag-selector-test.js
@@ -38,5 +38,10 @@ test('makeNSTagSelector escapes and name-spaces a selector', function(assert) {
     `:not(w\\:body,w\\:tc)`
   );
 
+  assert.equal(
+    w`sdt:first`,
+    `w\\:sdt:first`
+  );
+
   assert.end();
 });

--- a/tests/report-unless-test.js
+++ b/tests/report-unless-test.js
@@ -1,0 +1,36 @@
+let test = require('./get-test')();
+let reportUnless = require('../src/report-unless');
+
+test(`reportUnless works`, (assert) => {
+  assert.throws(
+    () => reportUnless(false, `foo`, { isUnitTest: true }),
+    `foo`,
+    `should throw when predicate false && unit test`
+  );
+  assert.doesNotThrow(
+    () => reportUnless(true, `bar`, { isUnitTest: true }),
+    `should not throw when predicate is true`
+  );
+
+  assert.doesNotThrow(
+    () => reportUnless(true, `bat`, { isUnitTest: false }),
+    `should not throw when predicate is true && not unit test`
+  );
+
+  let logged;
+  assert.doesNotThrow(
+    () => reportUnless(false, `baz`, { isUnitTest: false, log: (msg) => logged = msg }),
+    `should not throw when not unit test`
+  );
+  assert.equal(logged, `baz`, `message was logged`);
+
+  assert.ok(
+    reportUnless(false, `boof`, { isUnitTest: false }),
+    `reportUnless returns true when it does report`
+  );
+  assert.notOk(
+    reportUnless(true, `boof`, { isUnitTest: false }),
+    `reportUnless returns false when it does not report`
+  );
+  assert.end();
+})

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -1,7 +1,5 @@
 const cheerio = require('cheerio');
 
-const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
-
 const mix = require('../src/mixwith');
 
 const XmlPropertiesMixin = require('../src/xml-properties-mixin');
@@ -46,7 +44,7 @@ class TestProps extends mix().with(XmlPropertiesMixin, XmlNamespaceMixin) {
     return this.getArray(`thingie`);
   }
   pushThingies(...thingies) {
-    thingies.forEach((thingie, ii) => this.push(`thingie`, { id: ii, text: thingie }));
+    thingies.forEach((thingie, ii) => this.pushToArray(`thingie`, { id: ii, text: thingie }));
     return this;
   }
   clearThingies() {
@@ -56,6 +54,7 @@ class TestProps extends mix().with(XmlPropertiesMixin, XmlNamespaceMixin) {
 }
 
 test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
+  const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
 
   let $xml = $(`test-data`);
   // make an element that we'll attach properties to
@@ -125,6 +124,7 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
 
 
 test('XmlPropertiesMixin persists data in a Pr element with a namespace', function(assert) {
+  const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
 
   let $xml = $(`test-data`);
   // make an element that we'll attach properties to

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -84,7 +84,7 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
 
   props0.simpleString = '';
   assert.notOk(props0.simpleString, `simpleString property is get/settable`);
-  assert.equal($.html($p), `<p><testPr></testPr></p>`, `simpleString property is persisted in $xml`);
+  assert.equal($.html($p), `<p><testPr/></p>`, `simpleString property is persisted in $xml`);
 
   let props1 = new TestProps($p);
   props1.simpleString = 'xx';
@@ -112,13 +112,14 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
 
   // add a properties object using a different tag for the properties element
   let props2 = new TestProps($p, `otherTestPr`);
-  props2.simpleString = 'bar';
   props0.simpleString = 'foo';
+  props2.simpleString = 'bar';
   assert.equal(
     $.html($p),
     `<p><otherTestPr><simple-string val="bar"/></otherTestPr><testPr><simple-string val="foo"/></testPr></p>`,
     `multiple properties elements can co-exist on the same $root`
   );
+  props2.removePr();
 
   props0.simpleString = '';
   props0.emptyString = '';

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -24,17 +24,18 @@ class TestProps extends mix().with(XmlPropertiesMixin, XmlNamespaceMixin) {
     return this.getScalar(`simple-string`);
   }
   set simpleString(val) {
-    let tag = `simple-string`
-    if (val === null) {
-      let $simpleString = this.ensureProperty(tag);
-      $simpleString.remove();
-      return val;
-    }
-    return this.setScalar(tag, val);
+    return this.setOrRemoveScalar(`simple-string`, val);
+  }
+
+  get emptyString() {
+    return this.getScalar(`empty-string`);
+  }
+  set emptyString(val) {
+    return this.setScalar(`empty-string`, val);
   }
 
   get pojo() {
-    return this.getHash(`pojo`)
+    return this.getHash(`pojo`);
   }
   set pojo(obj) {
     return this.setHash(`pojo`, obj);
@@ -69,24 +70,24 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   assert.ok(props0.onOff, `onOff property is get/settable`);
   assert.equal($.html($p), `<p><testPr><on-off/></testPr></p>`, `onOff property is persisted in $xml`);
 
-  props0.onOff = false
+  props0.onOff = false;
   assert.notOk(props0.onOff, `onOff property is get/settable`);
   assert.equal($.html($p), `<p><testPr/></p>`, `onOff property is persisted in $xml`);
 
-  props0.simpleString = 'hi'
+  props0.simpleString = 'hi';
   assert.equal(props0.simpleString, `hi`, `simpleString property is get/settable`);
   assert.equal($.html($p), `<p><testPr><simple-string val="hi"/></testPr></p>`, `simpleString property is persisted in $xml`);
 
-  props0.simpleString = 'hello'
+  props0.simpleString = 'hello';
   assert.equal(props0.simpleString, `hello`, `simpleString property is get/settable`);
   assert.equal($.html($p), `<p><testPr><simple-string val="hello"/></testPr></p>`, `simpleString property is persisted in $xml`);
 
-  props0.simpleString = ''
-  assert.equal(props0.simpleString, ``, `simpleString property is get/settable`);
-  assert.equal($.html($p), `<p><testPr><simple-string val=""/></testPr></p>`, `simpleString property is persisted in $xml`);
+  props0.simpleString = '';
+  assert.notOk(props0.simpleString, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<p><testPr></testPr></p>`, `simpleString property is persisted in $xml`);
 
   let props1 = new TestProps($p);
-  props1.simpleString = 'xx'
+  props1.simpleString = 'xx';
   assert.equal(props0.simpleString, `xx`, `properties are not tied to a particular instance of TestProps`);
   props0.simpleString = null;
 
@@ -95,11 +96,11 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   assert.equal($.html($p), `<p><testPr><pojo foo="1" bar="2"/></testPr></p>`, `pojo property is persisted in $xml`);
   props0.removeProperty('pojo');
 
-  props1.pushThingies('monkey', 'wildebeest', 'lemur')
+  props1.pushThingies('monkey', 'wildebeest', 'lemur');
   assert.deepEqual(props0.thingies, [
     { id: '0', text: 'monkey' },
     { id: '1', text: 'wildebeest' },
-    { id: '2', text: 'lemur' }]
+    { id: '2', text: 'lemur' } ]
   );
   assert.equal(
     $.html($p),
@@ -112,16 +113,20 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   // add a properties object using a different tag for the properties element
   let props2 = new TestProps($p, `otherTestPr`);
   props2.simpleString = 'bar';
-  props0.simpleString = 'foo'
+  props0.simpleString = 'foo';
   assert.equal(
     $.html($p),
     `<p><otherTestPr><simple-string val="bar"/></otherTestPr><testPr><simple-string val="foo"/></testPr></p>`,
     `multiple properties elements can co-exist on the same $root`
   );
 
+  props0.simpleString = '';
+  props0.emptyString = '';
+  assert.equal(props0.emptyString, ``, `emptyString property is get/settable`);
+  assert.equal($.html($p), `<p><testPr><empty-string val=""/></testPr></p>`, `emptyString property is persisted in $xml`);
+
   assert.end();
 });
-
 
 test('XmlPropertiesMixin persists data in a Pr element with a namespace', function(assert) {
   const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
@@ -140,25 +145,25 @@ test('XmlPropertiesMixin persists data in a Pr element with a namespace', functi
   assert.ok(props.onOff, `onOff property is get/settable`);
   assert.equal($.html($p), `<w:p><foo:testPr><foo:on-off/></foo:testPr></w:p>`, `onOff property is persisted in $xml`);
 
-  props.onOff = false
+  props.onOff = false;
   assert.notOk(props.onOff, `onOff property is get/settable`);
   assert.equal($.html($p), `<w:p><foo:testPr/></w:p>`, `onOff property is persisted in $xml`);
 
-  props.simpleString = 'hi'
+  props.simpleString = 'hi';
   assert.equal(props.simpleString, `hi`, `simpleString property is get/settable`);
   assert.equal($.html($p), `<w:p><foo:testPr><foo:simple-string val="hi"/></foo:testPr></w:p>`, `simpleString property is persisted in $xml`);
 
-  props.simpleString = 'hello'
+  props.simpleString = 'hello';
   assert.equal(props.simpleString, `hello`, `simpleString property is get/settable`);
   assert.equal($.html($p), `<w:p><foo:testPr><foo:simple-string val="hello"/></foo:testPr></w:p>`, `simpleString property is persisted in $xml`);
 
-  props.simpleString = null
+  props.simpleString = null;
 
-  props.pushThingies('monkey', 'wildebeest', 'lemur')
+  props.pushThingies('monkey', 'wildebeest', 'lemur');
   assert.deepEqual(props.thingies, [
     { id: '0', text: 'monkey' },
     { id: '1', text: 'wildebeest' },
-    { id: '2', text: 'lemur' }]
+    { id: '2', text: 'lemur' } ]
   );
   assert.equal(
     $.html($p),

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -174,3 +174,21 @@ test('XmlPropertiesMixin persists data in a Pr element with a namespace', functi
 
   assert.end();
 });
+
+test(`XmlPropertiesMixin instances can copy themselves as a new type`, (assert) => {
+  const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
+
+  let $xml = $(`test-data`);
+  // make an element that we'll attach properties to
+  let $p = $(`<w:p>`);
+  $xml.append($p);
+
+  class Props1 {}
+
+  let props0 = new TestProps($p, `testPr`);
+  let props1 = props0.copyAs(Props1);
+
+  assert.ok(props0 instanceof TestProps);
+  assert.ok(props1 instanceof Props1);
+  assert.end();
+})

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -1,0 +1,159 @@
+const cheerio = require('cheerio');
+
+const $ = cheerio.load(`<?xml version="1.0" ?><test-data />`, { xmlMode: true });
+
+const mix = require('../src/mixwith');
+
+const XmlPropertiesMixin = require('../src/xml-properties-mixin');
+
+const test = require('./get-test')();
+
+// define a TestProps class with an on/off property, a simple string property, and an array property
+class TestProps extends mix().with(XmlPropertiesMixin) {
+  constructor($el, tag = `testPr`, namespace) {
+    super($el, tag, namespace);
+  }
+  get onOff() {
+    return this.getPropertyValue(`on-off`);
+  }
+  set onOff(onOff) {
+    // intro is on/off
+    let $prop = this.ensureProperty(`on-off`);
+    if (!onOff) {
+      $prop.remove();
+    }
+  }
+
+  get simpleString() {
+    return this.getPropertyValue(`simple-string`);
+  }
+  set simpleString(val) {
+    let $simpleString = this.ensureProperty(`simple-string`);
+    if (val === null) {
+      $simpleString.remove();
+      return;
+    }
+    this.setAttrs($simpleString, { val });
+  }
+
+  get thingies() {
+    return this.getArrayPropertyValue(`thingie`);
+  }
+  pushThingies(...thingies) {
+    thingies.forEach((thingie, ii) => this.push(`thingie`, { id: ii, text: thingie }));
+    return this;
+  }
+  clearThingies() {
+    this.removeProperty(`thingie`);
+    return this;
+  }
+}
+
+test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
+
+  let $xml = $(`test-data`);
+  // make an element that we'll attach properties to
+  let $p = $(`<p>`);
+  $xml.append($p);
+
+  let props0 = new TestProps($p);
+
+  assert.equal($.html($p), `<p/>`, `merely instantiating a properties instance does not modify $xml`);
+
+  props0.onOff = true;
+  assert.ok(props0.onOff, `onOff property is get/settable`);
+  assert.equal($.html($p), `<p><testPr><on-off/></testPr></p>`, `onOff property is persisted in $xml`);
+
+  props0.onOff = false
+  assert.notOk(props0.onOff, `onOff property is get/settable`);
+  assert.equal($.html($p), `<p><testPr/></p>`, `onOff property is persisted in $xml`);
+
+  props0.simpleString = 'hi'
+  assert.equal(props0.simpleString, `hi`, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<p><testPr><simple-string val="hi"/></testPr></p>`, `simpleString property is persisted in $xml`);
+
+  props0.simpleString = 'hello'
+  assert.equal(props0.simpleString, `hello`, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<p><testPr><simple-string val="hello"/></testPr></p>`, `simpleString property is persisted in $xml`);
+
+  props0.simpleString = ''
+  assert.equal(props0.simpleString, ``, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<p><testPr><simple-string val=""/></testPr></p>`, `simpleString property is persisted in $xml`);
+
+  let props1 = new TestProps($p);
+  props1.simpleString = 'xx'
+  assert.equal(props0.simpleString, `xx`, `properties are not tied to a particular instance of TestProps`);
+  props0.simpleString = null;
+
+  props1.pushThingies('monkey', 'wildebeest', 'lemur')
+  assert.deepEqual(props0.thingies, [
+    { id: '0', text: 'monkey' },
+    { id: '1', text: 'wildebeest' },
+    { id: '2', text: 'lemur' }]
+  );
+  assert.equal(
+    $.html($p),
+    `<p><testPr><thingie id="0" text="monkey"/><thingie id="1" text="wildebeest"/><thingie id="2" text="lemur"/></testPr></p>`,
+    `thingies array property is persisted in $xml`
+  );
+
+  props0.clearThingies();
+
+  // add a properties object using a different tag for the properties element
+  let props2 = new TestProps($p, `otherTestPr`);
+  props2.simpleString = 'bar';
+  props0.simpleString = 'foo'
+  assert.equal(
+    $.html($p),
+    `<p><otherTestPr><simple-string val="bar"/></otherTestPr><testPr><simple-string val="foo"/></testPr></p>`,
+    `multiple properties elements can co-exist on the same $root`
+  );
+
+  assert.end();
+});
+
+
+test('XmlPropertiesMixin persists data in a Pr element with a namespace', function(assert) {
+
+  let $xml = $(`test-data`);
+  // make an element that we'll attach properties to
+  let $p = $(`<w:p>`);
+  $xml.append($p);
+
+  // use namespace 'foo' for our properties element
+  let props = new TestProps($p, `testPr`, `foo`);
+
+  assert.equal($.html($p), `<w:p/>`, `merely instantiating a properties instance does not modify $xml`);
+
+  props.onOff = true;
+  assert.ok(props.onOff, `onOff property is get/settable`);
+  assert.equal($.html($p), `<w:p><foo:testPr><foo:on-off/></foo:testPr></w:p>`, `onOff property is persisted in $xml`);
+
+  props.onOff = false
+  assert.notOk(props.onOff, `onOff property is get/settable`);
+  assert.equal($.html($p), `<w:p><foo:testPr/></w:p>`, `onOff property is persisted in $xml`);
+
+  props.simpleString = 'hi'
+  assert.equal(props.simpleString, `hi`, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<w:p><foo:testPr><foo:simple-string val="hi"/></foo:testPr></w:p>`, `simpleString property is persisted in $xml`);
+
+  props.simpleString = 'hello'
+  assert.equal(props.simpleString, `hello`, `simpleString property is get/settable`);
+  assert.equal($.html($p), `<w:p><foo:testPr><foo:simple-string val="hello"/></foo:testPr></w:p>`, `simpleString property is persisted in $xml`);
+
+  props.simpleString = null
+
+  props.pushThingies('monkey', 'wildebeest', 'lemur')
+  assert.deepEqual(props.thingies, [
+    { id: '0', text: 'monkey' },
+    { id: '1', text: 'wildebeest' },
+    { id: '2', text: 'lemur' }]
+  );
+  assert.equal(
+    $.html($p),
+    `<w:p><foo:testPr><foo:thingie id="0" text="monkey"/><foo:thingie id="1" text="wildebeest"/><foo:thingie id="2" text="lemur"/></foo:testPr></w:p>`,
+    `thingies array property is persisted in $xml`
+  );
+
+  assert.end();
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,6 +1002,19 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
+eslint-plugin-ember-suave@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz#ea7d232a126562dcd8b1ee3aa2700ac3b626e514"
+  dependencies:
+    requireindex "~1.1.0"
+
+eslint-plugin-turbopatent@^0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-turbopatent/-/eslint-plugin-turbopatent-0.1.0.tgz#86df5f97047c49701a1da2828b69cb3c1a924c32"
+  dependencies:
+    eslint-plugin-ember-suave "^1.0.0"
+    requireindex "^1.1.0"
+
 eslint@^3.12.1:
   version "3.12.1"
   resolved "https://registry.yarnpkg.com/eslint/-/eslint-3.12.1.tgz#507a609fe251dfefd58fda03e6dbd7e851c07581"
@@ -2170,6 +2183,10 @@ require-uncached@^1.0.2:
   dependencies:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
+
+requireindex@^1.1.0, requireindex@~1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
 resolve-from@^1.0.0:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -863,6 +863,10 @@ detect-indent@^4.0.0:
   dependencies:
     repeating "^2.0.0"
 
+detect-node@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/detect-node/-/detect-node-2.0.3.tgz#a2033c09cc8e158d37748fbde7507832bd6ce127"
+
 diff@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/diff/-/diff-2.2.3.tgz#60eafd0d28ee906e4e8ff0a52c1229521033bf99"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1002,17 +1002,18 @@ escope@^3.6.0:
     esrecurse "^4.1.0"
     estraverse "^4.1.1"
 
-eslint-plugin-ember-suave@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-ember-suave/-/eslint-plugin-ember-suave-1.0.0.tgz#ea7d232a126562dcd8b1ee3aa2700ac3b626e514"
+eslint-plugin-ember@^3.1.2:
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-ember/-/eslint-plugin-ember-3.1.2.tgz#8387f59189cc0dcbd3a5ecbbafe34a330f118976"
   dependencies:
-    requireindex "~1.1.0"
+    requireindex "^1.1.0"
+    snake-case "^2.1.0"
 
-eslint-plugin-turbopatent@^0.1.0:
-  version "0.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-turbopatent/-/eslint-plugin-turbopatent-0.1.0.tgz#86df5f97047c49701a1da2828b69cb3c1a924c32"
+eslint-plugin-turbopatent@^0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-turbopatent/-/eslint-plugin-turbopatent-0.5.0.tgz#2ca8961c4ba29c727a5dfcc0b40f425895de8746"
   dependencies:
-    eslint-plugin-ember-suave "^1.0.0"
+    eslint-plugin-ember "^3.1.2"
     requireindex "^1.1.0"
 
 eslint@^3.12.1:
@@ -1762,6 +1763,10 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^2.0.0"
 
+lower-case@^1.1.1:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/lower-case/-/lower-case-1.1.4.tgz#9a2cabd1b9e8e0ae993a4bf7d5875c39c42e8eac"
+
 micromatch@^2.1.5:
   version "2.3.11"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-2.3.11.tgz#86677c97d1720b363431d04d0d15293bd38c1565"
@@ -1839,6 +1844,12 @@ nan@^2.3.0:
 natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
+
+no-case@^2.2.0:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/no-case/-/no-case-2.3.1.tgz#7aeba1c73a52184265554b7dc03baf720df80081"
+  dependencies:
+    lower-case "^1.1.1"
 
 node-pre-gyp@^0.6.29:
   version "0.6.32"
@@ -2184,7 +2195,7 @@ require-uncached@^1.0.2:
     caller-path "^0.1.0"
     resolve-from "^1.0.0"
 
-requireindex@^1.1.0, requireindex@~1.1.0:
+requireindex@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.1.0.tgz#e5404b81557ef75db6e49c5a72004893fe03e162"
 
@@ -2268,6 +2279,12 @@ slash@^1.0.0:
 slice-ansi@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/slice-ansi/-/slice-ansi-0.0.4.tgz#edbf8903f66f7ce2f8eafd6ceed65e264c831b35"
+
+snake-case@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/snake-case/-/snake-case-2.1.0.tgz#41bdb1b73f30ec66a04d4e2cad1b76387d4d6d9f"
+  dependencies:
+    no-case "^2.2.0"
 
 sntp@1.x.x:
   version "1.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -606,6 +606,10 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
+boolbase@~1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/boolbase/-/boolbase-1.0.0.tgz#68dff5fbe60c51eb37725ea9e3ed310dcc1e776e"
+
 boom@2.x.x:
   version "2.10.1"
   resolved "https://registry.yarnpkg.com/boom/-/boom-2.10.1.tgz#39c8918ceff5799f83f9492a848f625add0c766f"
@@ -664,6 +668,27 @@ chalk@^1.0.0, chalk@^1.1.0, chalk@^1.1.1, chalk@^1.1.3:
     has-ansi "^2.0.0"
     strip-ansi "^3.0.0"
     supports-color "^2.0.0"
+
+cheerio@^0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/cheerio/-/cheerio-0.22.0.tgz#a9baa860a3f9b595a6b81b1a86873121ed3a269e"
+  dependencies:
+    css-select "~1.2.0"
+    dom-serializer "~0.1.0"
+    entities "~1.1.1"
+    htmlparser2 "^3.9.1"
+    lodash.assignin "^4.0.9"
+    lodash.bind "^4.1.4"
+    lodash.defaults "^4.0.1"
+    lodash.filter "^4.4.0"
+    lodash.flatten "^4.2.0"
+    lodash.foreach "^4.3.0"
+    lodash.map "^4.4.0"
+    lodash.merge "^4.4.0"
+    lodash.pick "^4.2.1"
+    lodash.reduce "^4.4.0"
+    lodash.reject "^4.4.0"
+    lodash.some "^4.4.0"
 
 chokidar@^1.0.0:
   version "1.6.1"
@@ -752,6 +777,19 @@ cryptiles@2.x.x:
   dependencies:
     boom "2.x.x"
 
+css-select@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/css-select/-/css-select-1.2.0.tgz#2b3a110539c5355f1cd8d314623e870b121ec858"
+  dependencies:
+    boolbase "~1.0.0"
+    css-what "2.1"
+    domutils "1.5.1"
+    nth-check "~1.0.1"
+
+css-what@2.1:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/css-what/-/css-what-2.1.0.tgz#9467d032c38cfaefb9f2d79501253062f87fa1bd"
+
 d@^0.1.1, d@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/d/-/d-0.1.1.tgz#da184c535d18d8ee7ba2aa229b914009fae11309"
@@ -836,9 +874,37 @@ doctrine@^1.2.2:
     esutils "^2.0.2"
     isarray "^1.0.0"
 
+dom-serializer@0, dom-serializer@~0.1.0:
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
+  dependencies:
+    domelementtype "~1.1.1"
+    entities "~1.1.1"
+
 dom-walk@^0.1.0:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/dom-walk/-/dom-walk-0.1.1.tgz#672226dc74c8f799ad35307df936aba11acd6018"
+
+domelementtype@1, domelementtype@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.3.0.tgz#b17aed82e8ab59e52dd9c19b1756e0fc187204c2"
+
+domelementtype@~1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-1.1.3.tgz#bd28773e2642881aec51544924299c5cd822185b"
+
+domhandler@^2.3.0:
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-2.3.0.tgz#2de59a0822d5027fabff6f032c2b25a2a8abe738"
+  dependencies:
+    domelementtype "1"
+
+domutils@1.5.1, domutils@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/domutils/-/domutils-1.5.1.tgz#dcd8488a26f563d61079e48c9f7b7e32373682cf"
+  dependencies:
+    dom-serializer "0"
+    domelementtype "1"
 
 duplexer@^0.1.1:
   version "0.1.1"
@@ -849,6 +915,10 @@ ecc-jsbn@~0.1.1:
   resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz#0fc73a9ed5f0d53c38193398523ef7e543777505"
   dependencies:
     jsbn "~0.1.0"
+
+entities@^1.1.1, entities@~1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-1.1.1.tgz#6e5c2d0a5621b5dadaecef80b90edfb5cd7772f0"
 
 es-abstract@^1.5.0:
   version "1.6.1"
@@ -1315,6 +1385,17 @@ home-or-tmp@^2.0.0:
     os-homedir "^1.0.0"
     os-tmpdir "^1.0.1"
 
+htmlparser2@^3.9.1:
+  version "3.9.2"
+  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.9.2.tgz#1bdf87acca0f3f9e53fa4fcceb0f4b4cbb00b338"
+  dependencies:
+    domelementtype "^1.3.0"
+    domhandler "^2.3.0"
+    domutils "^1.5.1"
+    entities "^1.1.1"
+    inherits "^2.0.1"
+    readable-stream "^2.0.2"
+
 http-signature@~1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.1.1.tgz#df72e267066cd0ac67fb76adf8e134a8fbcf91bf"
@@ -1606,6 +1687,54 @@ levn@^0.3.0, levn@~0.3.0:
     prelude-ls "~1.1.2"
     type-check "~0.3.2"
 
+lodash.assignin@^4.0.9:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.assignin/-/lodash.assignin-4.2.0.tgz#ba8df5fb841eb0a3e8044232b0e263a8dc6a28a2"
+
+lodash.bind@^4.1.4:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/lodash.bind/-/lodash.bind-4.2.1.tgz#7ae3017e939622ac31b7d7d7dcb1b34db1690d35"
+
+lodash.defaults@^4.0.1:
+  version "4.2.0"
+  resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
+
+lodash.filter@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.filter/-/lodash.filter-4.6.0.tgz#668b1d4981603ae1cc5a6fa760143e480b4c4ace"
+
+lodash.flatten@^4.2.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.flatten/-/lodash.flatten-4.4.0.tgz#f31c22225a9632d2bbf8e4addbef240aa765a61f"
+
+lodash.foreach@^4.3.0:
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/lodash.foreach/-/lodash.foreach-4.5.0.tgz#1a6a35eace401280c7f06dddec35165ab27e3e53"
+
+lodash.map@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.map/-/lodash.map-4.6.0.tgz#771ec7839e3473d9c4cde28b19394c3562f4f6d3"
+
+lodash.merge@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.0.tgz#69884ba144ac33fe699737a6086deffadd0f89c5"
+
+lodash.pick@^4.2.1:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/lodash.pick/-/lodash.pick-4.4.0.tgz#52f05610fff9ded422611441ed1fc123a03001b3"
+
+lodash.reduce@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reduce/-/lodash.reduce-4.6.0.tgz#f1ab6b839299ad48f784abbf476596f03b914d3b"
+
+lodash.reject@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.reject/-/lodash.reject-4.6.0.tgz#80d6492dc1470864bbf583533b651f42a9f52415"
+
+lodash.some@^4.4.0:
+  version "4.6.0"
+  resolved "https://registry.yarnpkg.com/lodash.some/-/lodash.some-4.6.0.tgz#1bb9f314ef6b8baded13b549169b2a945eb68e4d"
+
 lodash@^3.3.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-3.10.1.tgz#5bf45e8e49ba4189e17d482789dfd15bd140b7b6"
@@ -1730,6 +1859,12 @@ npmlog@^4.0.1:
     console-control-strings "~1.1.0"
     gauge "~2.7.1"
     set-blocking "~2.0.0"
+
+nth-check@~1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nth-check/-/nth-check-1.0.1.tgz#9929acdf628fc2c41098deab82ac580cf149aae4"
+  dependencies:
+    boolbase "~1.0.0"
 
 number-is-nan@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Mixin to persist data in an xml properties element, similar to how properties are stored in pPr/rPr elements in ooxml. Ported from lib-validate + new namespace logic to allow use in an ooxml doc.