### PR TITLE
cache properties by tag in xml-properties-mixin to improve performance

### DIFF
--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -87,16 +87,22 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   //
   // find the $element(s) corresponding to a given tag in our $Pr element
   //
-  findProperty(tag) {
+  findProperty(tag, { noCache } = {}) {
     let { propertiesCache } = this;
-    if (propertiesCache.has(tag)) {
+    if (!noCache && propertiesCache.has(tag)) {
       return propertiesCache.get(tag);
     }
     let $prop = findChildren(this.$Pr, this.ensureNamespace(tag));
-    if ($prop.length) {
-      propertiesCache.set(tag, $prop);
-      return $prop;
+    if (!$prop.length) {
+      return;
     }
+    if (!noCache) {
+      // for non-array properties, there should be one $element per tag. Once
+      // the $element is created, it should persist until the property for that
+      // tag is removed
+      propertiesCache.set(tag, $prop);
+    }
+    return $prop;
   }
   //
   // return an $element for the given tag, creating it as a child of our $Pr
@@ -133,7 +139,8 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
   // get an array of pojo values for a given tag
   //
   getArray(tag) {
-    let $vals = this.findProperty(tag);
+    // don't cache array elements because they may come and go
+    let $vals = this.findProperty(tag, { noCache: true });
     if (!$vals) {
       return [];
     }

--- a/src/xml-properties-mixin.js
+++ b/src/xml-properties-mixin.js
@@ -85,13 +85,6 @@ let XmlPropertiesMixin = (superclass) => class extends superclass {
     return $prop;
   }
   //
-  // remove our $Pr element
-  //
-  removePr() {
-    this.propertiesCache.clear();
-    return this.$Pr.remove();
-  }
-  //
   // find the $element(s) corresponding to a given tag in our $Pr element
   //
   findProperty(tag) {

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -45,7 +45,7 @@ class TestProps extends mix().with(XmlPropertiesMixin, XmlNamespaceMixin) {
     return this.getArray(`thingie`);
   }
   pushThingies(...thingies) {
-    thingies.forEach((thingie, ii) => this.pushToArray(`thingie`, { id: ii, text: thingie }));
+    thingies.forEach((thingie) => this.pushToArray(`thingie`, { id: this.getArray(`thingie`).length, text: thingie }));
     return this;
   }
   clearThingies() {
@@ -98,7 +98,8 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   assert.equal($.html($p), `<p><testPr><pojo foo="1" bar="2"/></testPr></p>`, `pojo property is persisted in $xml`);
   props0.removeProperty('pojo');
 
-  props1.pushThingies('monkey', 'wildebeest', 'lemur');
+  props1.pushThingies('monkey');
+  props1.pushThingies('wildebeest', 'lemur');
   assert.deepEqual(props0.thingies, [
     { id: '0', text: 'monkey' },
     { id: '1', text: 'wildebeest' },
@@ -109,7 +110,7 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
     `<p><testPr><thingie id="0" text="monkey"/><thingie id="1" text="wildebeest"/><thingie id="2" text="lemur"/></testPr></p>`,
     `thingies array property is persisted in $xml`
   );
-  assert.ok(props0.propertiesCache.has(`thingie`), `thingies property is cached`);
+  assert.notOk(props0.propertiesCache.has(`thingie`), `thingies array property is not cached`);
 
   props0.clearThingies();
   assert.notOk(props0.propertiesCache.has(`thingie`), `thingies property is not cached after being cleared`);

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -123,13 +123,6 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
     `<p><otherTestPr><simple-string val="bar"/></otherTestPr><testPr><simple-string val="foo"/></testPr></p>`,
     `multiple properties elements can co-exist on the same $root`
   );
-  props2.removePr();
-
-  props0.simpleString = '';
-  props0.emptyString = '';
-  assert.equal(props0.emptyString, ``, `emptyString property is get/settable`);
-  assert.equal($.html($p), `<p><testPr><empty-string val=""/></testPr></p>`, `emptyString property is persisted in $xml`);
-
   assert.end();
 });
 

--- a/tests/xml-properties-mixin-test.js
+++ b/tests/xml-properties-mixin-test.js
@@ -69,6 +69,7 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   props0.onOff = true;
   assert.ok(props0.onOff, `onOff property is get/settable`);
   assert.equal($.html($p), `<p><testPr><on-off/></testPr></p>`, `onOff property is persisted in $xml`);
+  assert.ok(props0.propertiesCache.has(`on-off`), `onOff property is cached`);
 
   props0.onOff = false;
   assert.notOk(props0.onOff, `onOff property is get/settable`);
@@ -77,6 +78,7 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
   props0.simpleString = 'hi';
   assert.equal(props0.simpleString, `hi`, `simpleString property is get/settable`);
   assert.equal($.html($p), `<p><testPr><simple-string val="hi"/></testPr></p>`, `simpleString property is persisted in $xml`);
+  assert.ok(props0.propertiesCache.has(`simple-string`), `simpleString property is cached`);
 
   props0.simpleString = 'hello';
   assert.equal(props0.simpleString, `hello`, `simpleString property is get/settable`);
@@ -107,8 +109,10 @@ test('XmlPropertiesMixin persists data in a Pr element', function(assert) {
     `<p><testPr><thingie id="0" text="monkey"/><thingie id="1" text="wildebeest"/><thingie id="2" text="lemur"/></testPr></p>`,
     `thingies array property is persisted in $xml`
   );
+  assert.ok(props0.propertiesCache.has(`thingie`), `thingies property is cached`);
 
   props0.clearThingies();
+  assert.notOk(props0.propertiesCache.has(`thingie`), `thingies property is not cached after being cleared`);
 
   // add a properties object using a different tag for the properties element
   let props2 = new TestProps($p, `otherTestPr`);


### PR DESCRIPTION
When validating an 85 page document, we were spending >10-12 seconds traversing the dom to find properties. This PR speeds up the overall validation process by ~8%.
